### PR TITLE
Make ip_shared optional in the case of VPC as well

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -255,7 +255,7 @@ resource "aci_rest_managed" "l3extMember_A" {
 }
 
 resource "aci_rest_managed" "l3extIp_A" {
-  for_each   = { for item in local.interfaces : item.key => item.value if item.value.type == "vpc" }
+  for_each   = { for item in local.interfaces : item.key => item.value if item.value.type == "vpc" && item.value.ip_shared != null }
   dn         = "${aci_rest_managed.l3extMember_A[each.key].dn}/addr-[${each.value.ip_shared}]"
   class_name = "l3extIp"
   content = {
@@ -274,7 +274,7 @@ resource "aci_rest_managed" "l3extMember_B" {
 }
 
 resource "aci_rest_managed" "l3extIp_B" {
-  for_each   = { for item in local.interfaces : item.key => item.value if item.value.type == "vpc" }
+  for_each   = { for item in local.interfaces : item.key => item.value if item.value.type == "vpc" && item.value.ip_shared != null }
   dn         = "${aci_rest_managed.l3extMember_B[each.key].dn}/addr-[${each.value.ip_shared}]"
   class_name = "l3extIp"
   content = {


### PR DESCRIPTION
## Description

A secondary IP on L3Out interfaces (`var.interfaces[*].ip_shared` in this module) is optional regardless of the interface type (VPC, PC, individual port).

In the variable definition in `variables.tf`, `var.interfaces[*].ip_shared` is defined as optional. However, the resource implementation makes it required unnecessarily.

## Fix Suggestion

Make it optional just as the other interface types do.