### PR TITLE
Making the bgp peer password var sensitive

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ locals {
           next_hop_self                    = peer.next_hop_self
           send_community                   = peer.send_community
           send_ext_community               = peer.send_ext_community
-          password                         = peer.password
+          password                         = sensitive(peer.password)
           allowed_self_as_count            = peer.allowed_self_as_count
           bfd                              = peer.bfd
           disable_connected_check          = peer.disable_connected_check
@@ -89,7 +89,7 @@ locals {
           next_hop_self                    = peer.next_hop_self
           send_community                   = peer.send_community
           send_ext_community               = peer.send_ext_community
-          password                         = peer.password
+          password                         = sensitive(peer.password)
           allowed_self_as_count            = peer.allowed_self_as_count
           bfd                              = peer.bfd
           disable_connected_check          = peer.disable_connected_check
@@ -320,7 +320,7 @@ resource "aci_rest_managed" "bgpPeerP" {
     addr             = each.value.ip
     descr            = each.value.description
     ctrl             = join(",", concat(each.value.allow_self_as == true ? ["allow-self-as"] : [], each.value.as_override == true ? ["as-override"] : [], each.value.disable_peer_as_check == true ? ["dis-peer-as-check"] : [], each.value.next_hop_self == true ? ["nh-self"] : [], each.value.send_community == true ? ["send-com"] : [], each.value.send_ext_community == true ? ["send-ext-com"] : []))
-    password         = each.value.password
+    password         = sensitive(each.value.password)
     allowedSelfAsCnt = each.value.allowed_self_as_count
     peerCtrl         = join(",", concat(each.value.bfd == true ? ["bfd"] : [], each.value.disable_connected_check == true ? ["dis-conn-check"] : []))
     ttl              = each.value.ttl
@@ -391,7 +391,7 @@ resource "aci_rest_managed" "bgpPeerP_floating" {
     addr             = each.value.ip
     descr            = each.value.description
     ctrl             = join(",", concat(each.value.allow_self_as == true ? ["allow-self-as"] : [], each.value.as_override == true ? ["as-override"] : [], each.value.disable_peer_as_check == true ? ["dis-peer-as-check"] : [], each.value.next_hop_self == true ? ["nh-self"] : [], each.value.send_community == true ? ["send-com"] : [], each.value.send_ext_community == true ? ["send-ext-com"] : []))
-    password         = each.value.password
+    password         = sensitive(each.value.password)
     allowedSelfAsCnt = each.value.allowed_self_as_count
     peerCtrl         = join(",", concat(each.value.bfd == true ? ["bfd"] : [], each.value.disable_connected_check == true ? ["dis-conn-check"] : []))
     ttl              = each.value.ttl

--- a/variables.tf
+++ b/variables.tf
@@ -64,6 +64,7 @@ variable "ospf_authentication_key" {
   description = "OSPF authentication key."
   type        = string
   default     = ""
+  sensitive   = true
 }
 
 variable "ospf_authentication_key_id" {


### PR DESCRIPTION
Same approach as with the VMM vCenter passwords.