### PR TITLE
Add support for Colon ":" in multiple policies #235

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -282,9 +282,9 @@ variable "interfaces" {
 
   validation {
     condition = alltrue([
-      for i in var.interfaces : i.channel == null || try(can(regex("^[a-zA-Z0-9_.-]{0,64}$", i.channel)), false)
+      for i in var.interfaces : i.channel == null || try(can(regex("^[a-zA-Z0-9_.-:]{0,64}$", i.channel)), false)
     ])
-    error_message = "`channel`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
+    error_message = "`channel`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`, `:`. Maximum characters: 64."
   }
 
   validation {
@@ -338,9 +338,9 @@ variable "interfaces" {
 
   validation {
     condition = alltrue(flatten([
-      for i in var.interfaces : [for p in coalesce(i.paths, []) : p.physical_domain == null || try(can(regex("^[a-zA-Z0-9_.-]{0,64}$", p.physical_domain)))]
+      for i in var.interfaces : [for p in coalesce(i.paths, []) : p.physical_domain == null || try(can(regex("^[a-zA-Z0-9_.-:]{0,64}$", p.physical_domain)))]
     ]))
-    error_message = "`paths.physical_domain`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
+    error_message = "`paths.physical_domain`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`, `:`. Maximum characters: 64."
   }
 
   validation {


### PR DESCRIPTION
aci.aci_l3out_interface_profile_manual:

Port-Channel - var.interfaces : i.channel - added colon ":" Physical domains - i.paths - added colon ":"